### PR TITLE
Add Linux support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@
 lame-3.100/config.h
 [Oo]ut/**
 cmake-*/**
+build/**
+install/**
 
 # IDE Temp
 .vs/**

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ set (CMAKE_C_STANDARD 17)# Using C17
 set (CMAKE_C_EXTENSIONS OFF)
 set (CMAKE_C_STANDARD_REQUIRED ON)
 
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-implicit-function-declaration") # so that "strdup" doesn't cause an error on GCC
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-int-conversion") # so that int can be implicitly converted to char* on GCC
+
 set (CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")# Using /MD and /MDd on MSVC
 
 include(GNUInstallDirs)
@@ -143,7 +146,10 @@ if (${LAME_MP3X})
 	add_executable (mp3x ${SRC_PATH}/config.h ${COMMON_SRC} ${MPX_SRC} ${RC_SRC})
 endif (${LAME_MP3X})
 add_executable (mp3rtp ${SRC_PATH}/config.h ${COMMON_SRC} ${MP3RTP_SRC} ${RC_SRC})
-add_library (lame_enc SHARED ${SRC_PATH}/config.h ${DLL_SRC} ${RC_SRC})
+# DLL is not supported on GNU/Linux
+if (WIN32)
+	add_library (lame_enc SHARED ${SRC_PATH}/config.h ${DLL_SRC} ${RC_SRC})
+endif (WIN32)
 add_library (mp3lame SHARED ${SRC_PATH}/config.h ${DLL_DEF} ${SRC_PATH}/libmp3lame/version.c)
 add_library (mp3lame-static STATIC ${LAMELIB_SRC} ${MPGLIB_SRC})
 if (${LAME_ASM})
@@ -168,7 +174,10 @@ if (${LAME_MP3X})
 	target_include_directories (mp3x PRIVATE ${SRC_INC})
 endif (${LAME_MP3X})
 target_include_directories (mp3rtp PRIVATE ${SRC_INC})
-target_include_directories (lame_enc PRIVATE ${SRC_INC})
+# DLL is not supported on GNU/Linux
+if (WIN32)
+	target_include_directories (lame_enc PRIVATE ${SRC_INC})
+endif (WIN32)
 
 if (${LAME_ASM})
 	target_include_directories (lame_asm PRIVATE ${ASM_INC})
@@ -201,7 +210,10 @@ if (${LAME_MP3X})
 	target_compile_definitions (mp3x PUBLIC ${LAME_MACRO})
 endif (${LAME_MP3X})
 target_compile_definitions (mp3rtp PUBLIC ${LAME_MACRO})
-target_compile_definitions (lame_enc PUBLIC ${LAME_MACRO})
+# DLL is not supported on GNU/Linux
+if (WIN32)
+	target_compile_definitions (lame_enc PUBLIC ${LAME_MACRO})
+endif (WIN32)
 target_compile_definitions (mp3lame PUBLIC ${LAME_MACRO})
 target_compile_definitions (mp3lame-static PUBLIC ${LAME_MACRO})
 
@@ -210,9 +222,15 @@ if (${LAME_ASM} AND WIN32)
 endif (${LAME_ASM} AND WIN32)
 
 # Compile Settings
-set_target_properties (lame mp3rtp lame_enc mp3lame mp3lame-static
+set_target_properties (lame mp3rtp mp3lame mp3lame-static
 	PROPERTIES POSITION_INDEPENDENT_CODE ON
 )
+# lame_enc is only for Windows
+if (WIN32)
+	set_target_properties (lame_enc
+		PROPERTIES POSITION_INDEPENDENT_CODE ON
+	)
+endif(WIN32)
 if (${LAME_MP3X})
 	set_target_properties (mp3x
 	PROPERTIES POSITION_INDEPENDENT_CODE ON
@@ -235,13 +253,18 @@ if (WIN32)
 	set (WSOCK32_LIB wsock32)# Windows
 	set (USER32_LIB user32)# Windows
 endif (WIN32)
+if (NOT WIN32)
+	set (MATH_LIB m) # On Linux GCC it doesn't link the math library by default
+endif (NOT WIN32)
 
-target_link_libraries (lame PRIVATE mp3lame-static ${SNDFILE_LIB} ${ADDL_LIB})
+target_link_libraries (lame PRIVATE mp3lame-static ${SNDFILE_LIB} ${ADDL_LIB} ${MATH_LIB})
 if (${LAME_MP3X})
-	target_link_libraries (mp3x PRIVATE mp3lame-static ${SNDFILE_LIB} ${ADDL_LIB})
+	target_link_libraries (mp3x PRIVATE mp3lame-static ${SNDFILE_LIB} ${ADDL_LIB} ${MATH_LIB})
 endif (${LAME_MP3X})
-target_link_libraries (mp3rtp PRIVATE mp3lame-static ${SNDFILE_LIB} ${ADDL_LIB} ${WSOCK32_LIB})
-target_link_libraries (lame_enc PRIVATE mp3lame-static ${ADDL_LIB} ${USER32_LIB})
+target_link_libraries (mp3rtp PRIVATE mp3lame-static ${SNDFILE_LIB} ${ADDL_LIB} ${WSOCK32_LIB} ${MATH_LIB})
+if (WIN32) # Windows-only library
+	target_link_libraries (lame_enc PRIVATE mp3lame-static ${ADDL_LIB} ${USER32_LIB})
+endif (WIN32)
 target_link_libraries (mp3lame PRIVATE mp3lame-static)
 
 if (${LAME_ASM})
@@ -256,12 +279,20 @@ if (LAME_VCPKG_TOOLS_HINT)
 else ()
 	set(TOOLS_DIR ${CMAKE_INSTALL_BINDIR})
 endif ()
-install (TARGETS lame mp3rtp lame_enc mp3lame mp3lame-static
+install (TARGETS lame mp3rtp mp3lame mp3lame-static
 	EXPORT ${LAME_INSTALL_NAME}Targets
 	RUNTIME DESTINATION "${TOOLS_DIR}" OPTIONAL
 	LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" OPTIONAL
 	ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" OPTIONAL
 )
+if (WIN32) # Install DLL only on Windows
+	install (TARGETS lame_enc
+		EXPORT ${LAME_INSTALL_NAME}Targets
+		RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" OPTIONAL
+		LIBRARY DESTINATION "${CMAKE_INSTALL_BINDIR}" OPTIONAL
+		ARCHIVE DESTINATION "${CMAKE_INSTALL_BINDIR}" OPTIONAL
+	)
+endif (WIN32)
 if (${LAME_MP3X})
 	install (TARGETS mp3x
 		EXPORT ${LAME_INSTALL_NAME}Targets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,6 @@ set (CMAKE_C_STANDARD 17)# Using C17
 set (CMAKE_C_EXTENSIONS OFF)
 set (CMAKE_C_STANDARD_REQUIRED ON)
 
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-implicit-function-declaration") # so that "strdup" doesn't cause an error on GCC
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-int-conversion") # so that int can be implicitly converted to char* on GCC
-
 set (CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")# Using /MD and /MDd on MSVC
 
 include(GNUInstallDirs)
@@ -141,20 +138,34 @@ foreach (ASM_FILE ${ASM_SRC})
 	list (APPEND ASM_SRC_TEMP ${ASM_FILE_OUT})
 endforeach (ASM_FILE ${ASM_SRC})
 
+set (LAME_TARGET_LIST "")
 add_executable (lame ${SRC_PATH}/config.h ${COMMON_SRC} ${LAME_SRC} ${RC_SRC})
+list (APPEND LAME_TARGET_LIST lame)
 if (${LAME_MP3X})
 	add_executable (mp3x ${SRC_PATH}/config.h ${COMMON_SRC} ${MPX_SRC} ${RC_SRC})
+	list (APPEND LAME_TARGET_LIST mp3x)
 endif (${LAME_MP3X})
 add_executable (mp3rtp ${SRC_PATH}/config.h ${COMMON_SRC} ${MP3RTP_SRC} ${RC_SRC})
+list (APPEND LAME_TARGET_LIST mp3rtp)
 # DLL is not supported on GNU/Linux
 if (WIN32)
 	add_library (lame_enc SHARED ${SRC_PATH}/config.h ${DLL_SRC} ${RC_SRC})
+	list (APPEND LAME_TARGET_LIST lame_enc)
 endif (WIN32)
 add_library (mp3lame SHARED ${SRC_PATH}/config.h ${DLL_DEF} ${SRC_PATH}/libmp3lame/version.c)
+list (APPEND LAME_TARGET_LIST mp3lame)
 add_library (mp3lame-static STATIC ${LAMELIB_SRC} ${MPGLIB_SRC})
+list (APPEND LAME_TARGET_LIST mp3lame-static)
 if (${LAME_ASM})
 	add_library (lame_asm STATIC ${ASM_SRC_TEMP})
+	list (APPEND LAME_TARGET_LIST lame_asm)
 endif (${LAME_ASM})
+
+foreach (TARGET ${LAME_TARGET_LIST})
+	target_compile_options (${TARGET} PRIVATE
+		-Wno-implicit-function-declaration
+		-Wno-int-conversion)
+endforeach ()
 
 # Target Includes
 foreach (ITEM ${SRC_INC})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ set (CMAKE_C_STANDARD 17)# Using C17
 set (CMAKE_C_EXTENSIONS OFF)
 set (CMAKE_C_STANDARD_REQUIRED ON)
 
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-implicit-function-declaration") # so that "strdup" doesn't cause an error on GCC
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-int-conversion") # so that int can be implicitly converted to char* on GCC
+
 set (CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")# Using /MD and /MDd on MSVC
 
 include(GNUInstallDirs)
@@ -138,34 +141,20 @@ foreach (ASM_FILE ${ASM_SRC})
 	list (APPEND ASM_SRC_TEMP ${ASM_FILE_OUT})
 endforeach (ASM_FILE ${ASM_SRC})
 
-set (LAME_TARGET_LIST "")
 add_executable (lame ${SRC_PATH}/config.h ${COMMON_SRC} ${LAME_SRC} ${RC_SRC})
-list (APPEND LAME_TARGET_LIST lame)
 if (${LAME_MP3X})
 	add_executable (mp3x ${SRC_PATH}/config.h ${COMMON_SRC} ${MPX_SRC} ${RC_SRC})
-	list (APPEND LAME_TARGET_LIST mp3x)
 endif (${LAME_MP3X})
 add_executable (mp3rtp ${SRC_PATH}/config.h ${COMMON_SRC} ${MP3RTP_SRC} ${RC_SRC})
-list (APPEND LAME_TARGET_LIST mp3rtp)
 # DLL is not supported on GNU/Linux
 if (WIN32)
 	add_library (lame_enc SHARED ${SRC_PATH}/config.h ${DLL_SRC} ${RC_SRC})
-	list (APPEND LAME_TARGET_LIST lame_enc)
 endif (WIN32)
 add_library (mp3lame SHARED ${SRC_PATH}/config.h ${DLL_DEF} ${SRC_PATH}/libmp3lame/version.c)
-list (APPEND LAME_TARGET_LIST mp3lame)
 add_library (mp3lame-static STATIC ${LAMELIB_SRC} ${MPGLIB_SRC})
-list (APPEND LAME_TARGET_LIST mp3lame-static)
 if (${LAME_ASM})
 	add_library (lame_asm STATIC ${ASM_SRC_TEMP})
-	list (APPEND LAME_TARGET_LIST lame_asm)
 endif (${LAME_ASM})
-
-foreach (TARGET ${LAME_TARGET_LIST})
-	target_compile_options (${TARGET} PRIVATE
-		-Wno-implicit-function-declaration
-		-Wno-int-conversion)
-endforeach ()
 
 # Target Includes
 foreach (ITEM ${SRC_INC})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,11 @@ set (CMAKE_C_STANDARD 17)# Using C17
 set (CMAKE_C_EXTENSIONS OFF)
 set (CMAKE_C_STANDARD_REQUIRED ON)
 
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-implicit-function-declaration") # so that "strdup" doesn't cause an error on GCC
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-int-conversion") # so that int can be implicitly converted to char* on GCC
+set(ADDITIONAL_C_FLAGS "")
+if(NOT WIN32)
+	list (APPEND ADDITIONAL_C_FLAGS "-Wno-implicit-function-declaration") # so that "strdup" doesn't cause an error on GCC
+	list (APPEND ADDITIONAL_C_FLAGS "-Wno-int-conversion") # so that int can be implicitly converted to char* on GCC
+endif()
 
 set (CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")# Using /MD and /MDd on MSVC
 
@@ -237,8 +240,20 @@ if (${LAME_MP3X})
 )
 endif (${LAME_MP3X})
 
+target_compile_options (lame PRIVATE ${ADDITIONAL_C_FLAGS})
+if (${LAME_MP3X})
+target_compile_options (mp3x PRIVATE ${ADDITIONAL_C_FLAGS})
+endif (${LAME_MP3X})
+target_compile_options (mp3rtp PRIVATE ${ADDITIONAL_C_FLAGS})
+# DLL is not supported on GNU/Linux
+if (WIN32)
+	target_compile_options (lame_enc PRIVATE ${ADDITIONAL_C_FLAGS})
+endif (WIN32)
+target_compile_options (mp3lame PRIVATE ${ADDITIONAL_C_FLAGS})
+target_compile_options (mp3lame-static PRIVATE ${ADDITIONAL_C_FLAGS})
+
 if (${LAME_ASM} AND MSVC)
-	target_compile_options (lame_asm PRIVATE "-Sf")# MSVC
+	target_compile_options (lame_asm PRIVATE "-Sf" ${ADDITIONAL_C_FLAGS})# MSVC
 endif (${LAME_ASM} AND MSVC)
 
 # Link Libraries

--- a/README.md
+++ b/README.md
@@ -4,11 +4,20 @@ Use CMake to compile LAME library.
 ## Platform support
 - Windows (MSVC)
 - Windows (MinGW)
+- Linux (GCC)
 
 ## Target support
+### Windows
 - lame.exe - OK (Without NASM and libsndfile)
 - mp3x.exe - ERROR (No GTK Lib)
 - mp3rtp.exe - OK (Without NASM and libsndfile)
 - lame_enc.dll - OK (Without NASM and libsndfile)
 - mp3lame.dll - OK (Without NASM and libsndfile)
 - mp3lame-static.lib - OK (Without NASM and libsndfile)
+### Linux
+- lame - OK (Without NASM and libsndfile)
+- mp3x - ERROR (No GTK Lib)
+- mp3rtp - OK (Without NASM and libsndfile)
+- lame_enc.so - NOT SUPPORTED (Windows only)
+- mp3lame.so - OK (Without NASM and libsndfile)
+- mp3lame-static.a - OK (Without NASM and libsndfile)


### PR DESCRIPTION
将`lame_enc.dll`这一只能在Windows下构建的库在非Windows操作系统下排除；
加入两个编译选项以在GCC下通过编译。